### PR TITLE
support poetry v2 by conditionally setting some config options

### DIFF
--- a/scripts/install-poetry.sh
+++ b/scripts/install-poetry.sh
@@ -29,12 +29,17 @@ case "${INPUT_POETRY_VERSION}" in
     ;;
 esac
 
-poetry config virtualenvs.create true
-poetry config virtualenvs.in-project true
-poetry config virtualenvs.prefer-active-python true
+poetry config virtualenvs.create true;
+poetry config virtualenvs.in-project true;
+
+__POETRY_VERSION="$(poetry --version | sed -E 's/.*([*-9+]\.[0-9]+\.[0-9+]([\.\-][^\s])?)\)?.*/\1/gm;t')"
+__POETRY_VERSION_1_PATTERN="^1\..*"
+if [[ "${__POETRY_VERSION}" =~ ${__POETRY_VERSION_1_PATTERN} ]]; then
+  poetry config virtualenvs.prefer-active-python true;
+  poetry config warnings.export false;
+fi
 
 pipx inject poetry poetry-plugin-export;
-poetry config warnings.export false;
 
 for plugin in ${INPUT_POETRY_PLUGINS}; do
   pipx inject poetry "${plugin}";


### PR DESCRIPTION
# Summary

Support poetry ^2.0.0

# Why This Is Needed

Trying to set `virtualenvs.prefer-active-python` with poetry ^2.0.0 results in an error as this config option no longer exists.

# What Changed

## Added

- added check for poetry v1 before setting `virtualenvs.prefer-active-python`

## Fixed

- fixed an issue preventing use of poetry ^2.0.0
